### PR TITLE
port: update to 1.21.6

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,16 +4,16 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21.5
-yarn_mappings=1.21.5+build.1
-loader_version=0.16.12
+minecraft_version=1.21.6
+yarn_mappings=1.21.6+build.1
+loader_version=0.16.14
 
 # Mod Properties
 mod_version=0.7.0
-target_version=1.21.5
+target_version=1.21.6
 maven_group=me.contaria
 archives_base_name=anglesnap
 
 # Dependencies
-fabric_version=0.119.9+1.21.5
-modmenu_version=14.0.0-rc.2
+fabric_version=0.128.0+1.21.6
+modmenu_version=15.0.0-beta.3

--- a/src/main/java/me/contaria/anglesnap/AngleSnap.java
+++ b/src/main/java/me/contaria/anglesnap/AngleSnap.java
@@ -1,20 +1,22 @@
 package me.contaria.anglesnap;
 
+import com.mojang.blaze3d.pipeline.RenderPipeline;
 import com.mojang.logging.LogUtils;
 import me.contaria.anglesnap.config.AngleSnapConfig;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
-import net.fabricmc.fabric.api.client.rendering.v1.HudLayerRegistrationCallback;
-import net.fabricmc.fabric.api.client.rendering.v1.IdentifiedLayer;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderContext;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderEvents;
+import net.fabricmc.fabric.api.client.rendering.v1.hud.HudElementRegistry;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.font.TextRenderer;
+import net.minecraft.client.gl.RenderPipelines;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.option.KeyBinding;
 import net.minecraft.client.option.StickyKeyBinding;
 import net.minecraft.client.render.RenderLayer;
+import net.minecraft.client.render.RenderPhase;
 import net.minecraft.client.render.RenderTickCounter;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.util.math.MatrixStack;
@@ -63,7 +65,7 @@ public class AngleSnap implements ClientModInitializer {
         ));
 
         WorldRenderEvents.LAST.register(AngleSnap::renderOverlay);
-        HudLayerRegistrationCallback.EVENT.register(drawer -> drawer.attachLayerAfter(IdentifiedLayer.DEBUG, Identifier.of("anglesnap", "overlay"), AngleSnap::renderHud));
+        HudElementRegistry.addFirst(Identifier.of("anglesnap", "overlay"), AngleSnap::renderHud);
 
         ClientPlayConnectionEvents.JOIN.register((networkHandler, packetSender, client) -> {
             if (client.isIntegratedServerRunning()) {
@@ -124,7 +126,7 @@ public class AngleSnap implements ClientModInitializer {
 
         Matrix4f matrix4f = matrices.peek().getPositionMatrix();
         MinecraftClient client = MinecraftClient.getInstance();
-        RenderLayer layer = RenderLayer.getGuiTexturedOverlay(angle.getIcon());
+        RenderLayer layer = RenderLayer.getCelestial(angle.getIcon());
         VertexConsumer consumer = client.getBufferBuilders().getEffectVertexConsumers().getBuffer(layer);
         consumer.vertex(matrix4f, -1.0f, -1.0f, 0.0f).color(angle.color).texture(0.0f, 0.0f);
         consumer.vertex(matrix4f, -1.0f, 1.0f, 0.0f).color(angle.color).texture(0.0f, 1.0f);
@@ -168,7 +170,7 @@ public class AngleSnap implements ClientModInitializer {
         TextRenderer textRenderer = client.textRenderer;
         String text = String.format("%.3f / %.3f", MathHelper.wrapDegrees(client.player.getYaw()), MathHelper.wrapDegrees(client.player.getPitch()));
         context.fill(5, 5, 5 + 2 + textRenderer.getWidth(text) + 2, 5 + 2 + textRenderer.fontHeight + 2, -1873784752);
-        context.drawText(textRenderer, text, 5 + 2 + 1, 5 + 2 + 1, 14737632, false);
+        context.drawText(textRenderer, text, 5 + 2 + 1, 5 + 2 + 1, -2039584, false);
     }
 
     public static boolean isInMultiplayer() {

--- a/src/main/java/me/contaria/anglesnap/gui/screen/IconButtonWidget.java
+++ b/src/main/java/me/contaria/anglesnap/gui/screen/IconButtonWidget.java
@@ -1,5 +1,7 @@
 package me.contaria.anglesnap.gui.screen;
 
+import com.mojang.blaze3d.pipeline.RenderPipeline;
+import net.minecraft.client.gl.RenderPipelines;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.tooltip.Tooltip;
 import net.minecraft.client.gui.widget.ButtonWidget;
@@ -26,7 +28,8 @@ public class IconButtonWidget extends ButtonWidget {
 
     @Override
     protected void renderWidget(DrawContext context, int mouseX, int mouseY, float delta) {
-        context.drawTexture(RenderLayer::getGuiTextured, this.texture, this.getX(), this.getY(), 0, 0, this.getWidth(), this.getHeight(), 16, 16);
+        context.drawTexture(RenderPipelines.GUI_TEXTURED, this.texture, this.getX(), this.getY(), 0, 0
+                , this.getWidth(), this.getHeight(), 16, 16);
     }
 
     public void setTexture(Identifier texture) {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -40,8 +40,8 @@
   ],
   "depends": {
     "fabricloader": ">=0.16.10",
-    "minecraft": "1.21.5",
+    "minecraft": "1.21.6",
     "java": ">=21",
-    "fabric-api": ">=0.116.0"
+    "fabric-api": ">=0.128.0"
   }
 }


### PR DESCRIPTION
Hello!

I managed to port the mod to 1.21.6

- Changed some properties and dependencies from `gradle.properties`. I am not sure if they are minimal, but they work just fine when I tested it.
- Icons are now rendered with `getCelestial()` instead of `getGuiTexturedOverlay()`, since its one of the `RenderLayer`s that accepts the vertex format that is already there. (And it also works)
- Changed the color of the text in the AngleHud -> Alpha was zero for some reason
- Changed the syntax from a few locations around the code where errors were given from the 1.21.5 version of the mod.